### PR TITLE
Allow :focus-within to appear escaped in a selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import postcss from 'postcss';
 
-const selectorRegExp = /:focus-within([^\w-]|$)/gi;
+const selectorRegExp = /(?<!\\):focus-within([^\w-]|$)/gi;
 
 export default postcss.plugin('postcss-focus-within', opts => {
 	const replaceWith = String(Object(opts).replaceWith || '[focus-within]');

--- a/test/basic.css
+++ b/test/basic.css
@@ -25,3 +25,10 @@ test :matches(test :focus-within :focus-within test) test {
 :focus-withinignore {
 	order: 3;
 }
+
+.escaped\:focus-within,
+.escaped\:times\:two\:focus-within,
+.escaped\:focus-within:focus-within,
+.escaped\:times\:two:focus-within {
+	order: 4;
+}

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -46,3 +46,17 @@ test :matches(test :focus-within :focus-within test) test {
 :focus-withinignore {
 	order: 3;
 }
+
+.escaped\:focus-within,
+.escaped\:times\:two\:focus-within,
+.escaped\:focus-within[focus-within],
+.escaped\:times\:two[focus-within] {
+	order: 4;
+}
+
+.escaped\:focus-within,
+.escaped\:times\:two\:focus-within,
+.escaped\:focus-within:focus-within,
+.escaped\:times\:two:focus-within {
+	order: 4;
+}

--- a/test/basic.preserve.expect.css
+++ b/test/basic.preserve.expect.css
@@ -25,3 +25,10 @@ test :matches(test [focus-within] [focus-within] test) test {
 :focus-withinignore {
 	order: 3;
 }
+
+.escaped\:focus-within,
+.escaped\:times\:two\:focus-within,
+.escaped\:focus-within[focus-within],
+.escaped\:times\:two[focus-within] {
+	order: 4;
+}

--- a/test/basic.replacewith.expect.css
+++ b/test/basic.replacewith.expect.css
@@ -46,3 +46,17 @@ test :matches(test :focus-within :focus-within test) test {
 :focus-withinignore {
 	order: 3;
 }
+
+.escaped\:focus-within,
+.escaped\:times\:two\:focus-within,
+.escaped\:focus-within.focus-within,
+.escaped\:times\:two.focus-within {
+	order: 4;
+}
+
+.escaped\:focus-within,
+.escaped\:times\:two\:focus-within,
+.escaped\:focus-within:focus-within,
+.escaped\:times\:two:focus-within {
+	order: 4;
+}


### PR DESCRIPTION
Fixes #3 

cc @adamwathan